### PR TITLE
Feat premium

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Setup for local dev
 
-### backend
+### Backend
 ```bash
 cd backend
 cp .env.example .env
@@ -11,27 +11,27 @@ php artisan key:generate
 php artisan migrate
 composer run dev
 ```
-you're app should be running on (https://localhost:8000)[https://localhost:8000]
+Your app should be running on [https://localhost:8000](https://localhost:8000)
 
-### frontend
+### Frontend
 ```bash
 cd frontend
 npm i
 npm run dev
 ```
 
-you're app should be running on (https://localhost:3000)[https://localhost:3000]
+Your app should be running on [https://localhost:3000](https://localhost:3000)
 
-## Api testing and documentation with Bruno
-Bruno is an open source offline api client that supports sharing via git, with bruno you can document and also test the endpoint on the fly being up to date with git.
+## API testing and documentation with Bruno
+Bruno is an open source offline API client that supports sharing via git. With Bruno, you can document and also test the endpoint on the fly while staying up to date with git.
 
-- Install bruno and open [https://www.usebruno.com/]
+- Install Bruno from [https://www.usebruno.com/](https://www.usebruno.com/)
 - Import `/bruno/shafaq` collection
 ![image](https://github.com/user-attachments/assets/04f77465-bb08-44c2-825f-a15dff9367f6)
-- change environment to local
+- Change environment to local
 ![image](https://github.com/user-attachments/assets/40d06d4a-d273-4837-88d4-889042177aad)
 
-- before making you register or login make sure to call the `auth/csrf` request first
+- Before making your register or login, make sure to call the `auth/csrf` request first
 
 ## Testing
 ```bash
@@ -40,65 +40,63 @@ composer test
 
 ## Deployment
 
-- Vercel for both backend and frontend.
-- Postgresql data base from xata.
+- Vercel for both backend and frontend
+- PostgreSQL database from Xata
 
 ## Premium feature simulation
 
 ### Requirements
-- Simulate integration with a payment gateway (e.g., a mock payment form) to
-“unlock” premium features, such as marking a task as “priority” or accessing
-extra task details.
+- Simulate integration with a payment gateway (e.g., a mock payment form) to "unlock" premium features, such as marking a task as "priority" or accessing extra task details.
 
 ### Note
-For billing I went with laravel cashier, in a real web app where I would have same domain for both backend and frontend I would use sessions and cookie for auth.
+For billing, I went with Laravel Cashier. In a real web app where I would have the same domain for both backend and frontend, I would use sessions and cookies for auth.
 The checkout flow would be as follows:
 
-1- user clicks on link and it triggers get request `/subscription-checkout`
-2- the api would redirect to the checkout page
+1. User clicks on link and it triggers GET request `/subscription-checkout`
+2. The API would redirect to the checkout page
 
-Since I'm hosting with vercel public domains I can't use server side cookies on the frontend and I can't redirect the user, therefore I went with sending the link in a json response.
+Since I'm hosting with Vercel public domains I can't use server-side cookies on the frontend and I can't redirect the user, therefore I went with sending the link in a JSON response.
 
-> [!info]
-> Use fake sandbox credit card number for checkout `4242 4242 4242 4242`
+> [!IMPORTANT]
+> Use fake sandbox credit card number for checkout: `4242 4242 4242 4242`
 
 ### Plan
 
-[x] Setup
-    [x] Install and setup Laravel Cashier with stripe
-    [x] Hook in my dev sandbox account
-    [x] Create a subscription plan for shafaq-premium
-    [x] Use `stripe cli` to receive webhooks in devl (as a docker container for better DX)
-    [x] Add stripe route to allowed origins
+- [x] Setup
+  - [x] Install and setup Laravel Cashier with Stripe
+  - [x] Hook in my dev sandbox account
+  - [x] Create a subscription plan for shafaq-premium
+  - [x] Use `stripe cli` to receive webhooks in dev (as a Docker container for better DX)
+  - [x] Add Stripe route to allowed origins
 
-[x] Backend
-    [-] Make tests as I go
-    [x] Make the checkout route
-    [x] Make a billing service interface
-    [x] Make a stripe/paddle billing service implementation
-    [x] Make a fake implementation for testing ? or research best way to do it (if I have time)
-    [x] Make a subscription middleware to protect premium routes
-    [x] Update User resource to include isSubscribed boolean info
+- [x] Backend
+  - [ ] Make tests as I go
+  - [x] Make the checkout route
+  - [x] Make a billing service interface
+  - [x] Make a Stripe/Paddle billing service implementation
+  - [x] Make a fake implementation for testing ? or research best way to do it (if I have time)
+  - [x] Make a subscription middleware to protect premium routes
+  - [x] Update User resource to include isSubscribed boolean info
 
-[x] Frontend
-    [x] Design a premium popup component and add it to auth layout
-    [x] Add subscription status to the header of the page
-    [x] Add a store for ui, that handles triggering the popup
-    [x] Mark buttons or elements that are premium with data-attribute for tracking
-    [x] Make a `premiumCheck` utility, that takes a user and handle function, if user is subscribed call the handle. else show premium popup
-    [x] Add a success/failure payment page
+- [x] Frontend
+  - [x] Design a premium popup component and add it to auth layout
+  - [x] Add subscription status to the header of the page
+  - [x] Add a store for UI, that handles triggering the popup
+  - [x] Mark buttons or elements that are premium with data-attribute for tracking
+  - [x] Make a `premiumCheck` utility, that takes a user and handle function, if user is subscribed call the handle. else show premium popup
+  - [x] Add a success/failure payment page
 
-[x] come up with a premium feature
+- [x] Come up with a premium feature
 
-[ ] Deployment
-    [ ] run migrations
-    [ ] Setup webhook url in stripe dashboard to point to production url
+- [ ] Deployment
+  - [ ] Run migrations
+  - [ ] Setup webhook URL in Stripe dashboard to point to production URL
 
 ### Docs
-Steps to use stripe in local development:
+Steps to use Stripe in local development:
 
-1- Create a stripe account and use Test sandbox mode
-2- Get these credentials and add them to your .env, refer to laravel cashier and stripe docs (pretend this is a link)[]
+1. Create a Stripe account and use Test sandbox mode
+2. Get these credentials and add them to your .env, refer to Laravel Cashier and Stripe docs
 
 ```
 # stripe
@@ -107,7 +105,7 @@ STRIPE_KEY=your-stripe-key
 STRIPE_SECRET=your-stripe-secret
 ```
 
-3- Launch stripe cli and copy the webhook secret form the output
+3. Launch Stripe CLI and copy the webhook secret from the output
 
 ```bash
 cd backend
@@ -124,11 +122,12 @@ docker compose up --build
 STRIPE_WEBHOOK_SECRET=your-stripe-webhook-secret
 ```
 
-4- Create a basic product (subscription) and add the id to .env
+4. Create a basic product (subscription) and add the ID to .env
 
 ```
 STRIPE_SUBSCRIPTION_PRICE_ID=price_test
 ```
+
 ## Todo
-[ ] refactor Button duplication to primary button 
-[ ] add ui notifications
+- [ ] Refactor Button duplication to primary button 
+- [ ] Add UI notifications

--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ composer test
 
 ## Premium feature simulation
 
-### Requirements
-- Simulate integration with a payment gateway (e.g., a mock payment form) to "unlock" premium features, such as marking a task as "priority" or accessing extra task details.
-
 ### Note
 For billing, I went with Laravel Cashier. In a real web app where I would have the same domain for both backend and frontend, I would use sessions and cookies for auth.
 The checkout flow would be as follows:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ php artisan key:generate
 php artisan migrate
 composer run dev
 ```
+you're app should be running on (https://localhost:8000)[https://localhost:8000]
 
 ### frontend
 ```bash
@@ -18,6 +19,8 @@ cd frontend
 npm i
 npm run dev
 ```
+
+you're app should be running on (https://localhost:3000)[https://localhost:3000]
 
 ## Api testing and documentation with Bruno
 Bruno is an open source offline api client that supports sharing via git, with bruno you can document and also test the endpoint on the fly being up to date with git.
@@ -39,3 +42,39 @@ composer test
 
 - Vercel for both backend and frontend.
 - Postgresql data base from xata.
+
+## Premium feature simulation
+
+### Requirements
+- Simulate integration with a payment gateway (e.g., a mock payment form) to
+“unlock” premium features, such as marking a task as “priority” or accessing
+extra task details.
+
+### Plan
+
+[ ] Setup
+    [ ] Install Laravel Cachier with stripe or paddle and setup
+    [ ] Hook in my dev sandbox account
+    [ ] Create a subscription plan for shafaq-premium
+    [ ] Use `expose` to receive webhooks in dev
+    [ ] Add stripe route to allowed origins
+
+[ ] Backend
+    [ ] Make tests as I go
+    [ ] Make a billing service interface
+    [ ] Make a stripe/paddle billing service implementation
+    [ ] Make a fake implementation for testing ? of research best way to do it (if I have time)
+    [ ] Make the checkout route
+    [ ] Make a subscription middleware to protect premium routes
+    [ ] Update User resource to include isSubscribed boolean info
+
+[ ] Frontend
+    [ ] Design a premium popup component
+    [ ] Add subscription status to the header of the page
+    [ ] Mark buttons or elements that are premium with data-attribute for tracking and marketing purposes
+    [ ] Make a `premiumCheck` utility, that takes a user and handle function, if user is subscribed call the handle. else show premium popup
+
+[ ] Deployment
+    [ ] run migrations
+    [ ] Setup webhook url in stripe dashboard to point to production url
+

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ The checkout flow would be as follows:
 
 Since I'm hosting with vercel public domains I can't use server side cookies on the frontend and I can't redirect the user, therefore I went with sending the link in a json response.
 
+> [!info]
+> Use fake sandbox credit card number for checkout `4242 4242 4242 4242`
+
 ### Plan
 
 [x] Setup
@@ -77,19 +80,19 @@ Since I'm hosting with vercel public domains I can't use server side cookies on 
     [x] Make a subscription middleware to protect premium routes
     [x] Update User resource to include isSubscribed boolean info
 
-[ ] Frontend
-    [ ] Design a premium popup component
-    [ ] Add subscription status to the header of the page
-    [ ] Mark buttons or elements that are premium with data-attribute for tracking and marketing purposes
-    [ ] Make a `premiumCheck` utility, that takes a user and handle function, if user is subscribed call the handle. else show premium popup
-    [ ] Add a success/failure payment page
+[x] Frontend
+    [x] Design a premium popup component and add it to auth layout
+    [x] Add subscription status to the header of the page
+    [x] Add a store for ui, that handles triggering the popup
+    [x] Mark buttons or elements that are premium with data-attribute for tracking
+    [x] Make a `premiumCheck` utility, that takes a user and handle function, if user is subscribed call the handle. else show premium popup
+    [x] Add a success/failure payment page
 
-[ ] come up with a premium feature
+[x] come up with a premium feature
 
 [ ] Deployment
     [ ] run migrations
     [ ] Setup webhook url in stripe dashboard to point to production url
-
 
 ### Docs
 Steps to use stripe in local development:
@@ -126,4 +129,6 @@ STRIPE_WEBHOOK_SECRET=your-stripe-webhook-secret
 ```
 STRIPE_SUBSCRIPTION_PRICE_ID=price_test
 ```
-
+## Todo
+[ ] refactor Button duplication to primary button 
+[ ] add ui notifications

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ extra task details.
 ### Plan
 
 [ ] Setup
-    [ ] Install Laravel Cachier with stripe or paddle and setup
-    [ ] Hook in my dev sandbox account
-    [ ] Create a subscription plan for shafaq-premium
-    [ ] Use `expose` to receive webhooks in dev
-    [ ] Add stripe route to allowed origins
+    [x] Install and setup Laravel Cashier with stripe
+    [x] Hook in my dev sandbox account
+    [x] Create a subscription plan for shafaq-premium
+    [x] Use `stripe cli` to receive webhooks in devl (as a docker container for better DX)
+    [x] Add stripe route to allowed origins
 
 [ ] Backend
     [ ] Make tests as I go
@@ -73,8 +73,45 @@ extra task details.
     [ ] Add subscription status to the header of the page
     [ ] Mark buttons or elements that are premium with data-attribute for tracking and marketing purposes
     [ ] Make a `premiumCheck` utility, that takes a user and handle function, if user is subscribed call the handle. else show premium popup
+    [ ] Add a success/failure payment page
 
 [ ] Deployment
     [ ] run migrations
     [ ] Setup webhook url in stripe dashboard to point to production url
+
+
+### Docs
+Steps to use stripe in local development:
+
+1- Create a stripe account and use Test sandbox mode
+2- Get these credentials and add them to your .env, refer to laravel cashier and stripe docs (pretend this is a link)[]
+
+```
+# stripe
+
+STRIPE_KEY=your-stripe-key
+STRIPE_SECRET=your-stripe-secret
+```
+
+3- Launch stripe cli and copy the webhook secret form the output
+
+```bash
+docker compose up --build
+ ✔ Container stripe-cli  Recreated                                                                                                                                     0.1s
+# Attaching to stripe-cli
+# stripe-cli  | Checking for new versions...
+# stripe-cli  |
+# stripe-cli  | Getting ready...
+# stripe-cli  | Ready! You are using Stripe API Version [2025-02-24.acacia]. Your webhook signing secret is whsec_fcb45dc0aea978647f1564b2d600fe025d74b53038401d4e5d124f5abf94260c (^C to quit)
+```
+
+```
+STRIPE_WEBHOOK_SECRET=your-stripe-webhook-secret
+```
+
+4- Create a basic product (subscription) and add the id to .env
+
+```
+STRIPE_SUBSCRIPTION_PRODUCT_ID=prod_your-product-id
+```
 

--- a/README.md
+++ b/README.md
@@ -50,23 +50,32 @@ composer test
 “unlock” premium features, such as marking a task as “priority” or accessing
 extra task details.
 
+### Note
+For billing I went with laravel cashier, in a real web app where I would have same domain for both backend and frontend I would use sessions and cookie for auth.
+The checkout flow would be as follows:
+
+1- user clicks on link and it triggers get request `/subscription-checkout`
+2- the api would redirect to the checkout page
+
+Since I'm hosting with vercel public domains I can't use server side cookies on the frontend and I can't redirect the user, therefore I went with sending the link in a json response.
+
 ### Plan
 
-[ ] Setup
+[x] Setup
     [x] Install and setup Laravel Cashier with stripe
     [x] Hook in my dev sandbox account
     [x] Create a subscription plan for shafaq-premium
     [x] Use `stripe cli` to receive webhooks in devl (as a docker container for better DX)
     [x] Add stripe route to allowed origins
 
-[ ] Backend
-    [ ] Make tests as I go
-    [ ] Make a billing service interface
-    [ ] Make a stripe/paddle billing service implementation
-    [ ] Make a fake implementation for testing ? of research best way to do it (if I have time)
-    [ ] Make the checkout route
-    [ ] Make a subscription middleware to protect premium routes
-    [ ] Update User resource to include isSubscribed boolean info
+[x] Backend
+    [-] Make tests as I go
+    [x] Make the checkout route
+    [x] Make a billing service interface
+    [x] Make a stripe/paddle billing service implementation
+    [x] Make a fake implementation for testing ? or research best way to do it (if I have time)
+    [x] Make a subscription middleware to protect premium routes
+    [x] Update User resource to include isSubscribed boolean info
 
 [ ] Frontend
     [ ] Design a premium popup component
@@ -74,6 +83,8 @@ extra task details.
     [ ] Mark buttons or elements that are premium with data-attribute for tracking and marketing purposes
     [ ] Make a `premiumCheck` utility, that takes a user and handle function, if user is subscribed call the handle. else show premium popup
     [ ] Add a success/failure payment page
+
+[ ] come up with a premium feature
 
 [ ] Deployment
     [ ] run migrations
@@ -96,13 +107,14 @@ STRIPE_SECRET=your-stripe-secret
 3- Launch stripe cli and copy the webhook secret form the output
 
 ```bash
+cd backend
 docker compose up --build
  ✔ Container stripe-cli  Recreated                                                                                                                                     0.1s
 # Attaching to stripe-cli
 # stripe-cli  | Checking for new versions...
 # stripe-cli  |
 # stripe-cli  | Getting ready...
-# stripe-cli  | Ready! You are using Stripe API Version [2025-02-24.acacia]. Your webhook signing secret is whsec_fcb45dc0aea978647f1564b2d600fe025d74b53038401d4e5d124f5abf94260c (^C to quit)
+# stripe-cli  | Ready! You are using Stripe API Version [2025-02-24.acacia]. Your webhook signing secret is whsec_***** (^C to quit)
 ```
 
 ```
@@ -112,6 +124,6 @@ STRIPE_WEBHOOK_SECRET=your-stripe-webhook-secret
 4- Create a basic product (subscription) and add the id to .env
 
 ```
-STRIPE_SUBSCRIPTION_PRODUCT_ID=prod_your-product-id
+STRIPE_SUBSCRIPTION_PRICE_ID=price_test
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Since I'm hosting with Vercel public domains I can't use server-side cookies on 
   - [x] Add Stripe route to allowed origins
 
 - [x] Backend
-  - [ ] Make tests as I go
+  - [x] Make tests as I go
   - [x] Make the checkout route
   - [x] Make a billing service interface
   - [x] Make a Stripe/Paddle billing service implementation
@@ -88,9 +88,9 @@ Since I'm hosting with Vercel public domains I can't use server-side cookies on 
 
 - [x] Come up with a premium feature
 
-- [ ] Deployment
-  - [ ] Run migrations
-  - [ ] Setup webhook URL in Stripe dashboard to point to production URL
+- [x] Deployment
+  - [x] Run migrations
+  - [x] Setup webhook URL in Stripe dashboard to point to production URL
 
 ### Docs
 Steps to use Stripe in local development:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -70,5 +70,5 @@ VITE_APP_NAME="${APP_NAME}"
 STRIPE_KEY=your-stripe-key
 STRIPE_SECRET=your-stripe-secret
 STRIPE_WEBHOOK_SECRET=your-stripe-webhook-secret
-STRIPE_SUBSCRIPTION_PRODUCT_ID=prod_your-product-id
+STRIPE_SUBSCRIPTION_PRICE_ID=price_test
 STRIPE_DEVICE_NAME=local-dev-stripe-cli-webhook

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -64,3 +64,11 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+# stripe
+
+STRIPE_KEY=your-stripe-key
+STRIPE_SECRET=your-stripe-secret
+STRIPE_WEBHOOK_SECRET=your-stripe-webhook-secret
+STRIPE_SUBSCRIPTION_PRODUCT_ID=prod_your-product-id
+STRIPE_DEVICE_NAME=local-dev-stripe-cli-webhook

--- a/backend/app/Http/Controllers/CheckoutController.php
+++ b/backend/app/Http/Controllers/CheckoutController.php
@@ -16,7 +16,7 @@ class CheckoutController extends Controller
         $user = $request->user();
         $url = $billingService->buildCheckoutLink($user, $request->string('success_url'), $request->string('cancel_url'));
 
-        //NOTE: would be a redirect in a real app (all server side)
+        // NOTE: would be a redirect in a real app (all server side)
         return response()->json(['data' => [
             'checkoutLink' => $url,
         ]], 201);

--- a/backend/app/Http/Controllers/CheckoutController.php
+++ b/backend/app/Http/Controllers/CheckoutController.php
@@ -18,7 +18,7 @@ class CheckoutController extends Controller
 
         //NOTE: would be a redirect in a real app (all server side)
         return response()->json(['data' => [
-            'checkout-link' => $url,
+            'checkoutLink' => $url,
         ]], 201);
     }
 }

--- a/backend/app/Http/Controllers/CheckoutController.php
+++ b/backend/app/Http/Controllers/CheckoutController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\CheckoutRequest;
+use App\Services\BillingServices\BillingService;
+
+class CheckoutController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(CheckoutRequest $request, BillingService $billingService)
+    {
+        /** @var \App\Models\User */
+        $user = $request->user();
+        $url = $billingService->buildCheckoutLink($user, $request->string('success_url'), $request->string('cancel_url'));
+
+        //NOTE: would be a redirect in a real app (all server side)
+        return response()->json(['data' => [
+            'checkout-link' => $url,
+        ]], 201);
+    }
+}

--- a/backend/app/Http/Controllers/PremiumQuoteController.php
+++ b/backend/app/Http/Controllers/PremiumQuoteController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Artisan;
+
+class PremiumQuoteController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke()
+    {
+        Artisan::call('inspire');
+
+        return response()->json(['data' => ['quote' => Artisan::output()]]);
+    }
+}

--- a/backend/app/Http/Middleware/RequiresSubscriptionMiddleware.php
+++ b/backend/app/Http/Middleware/RequiresSubscriptionMiddleware.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\BillingServices\BillingService;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequiresSubscriptionMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next, bool $mustBeSubscribed = true): Response
+    {
+        /** @var \App\Models\User */
+        $user = $request->user();
+
+        /** @var \App\Services\BillingServices\BillingService */
+        $billingService = app(BillingService::class);
+
+        abort_if(! $user, 401, 'no user is provided');
+
+        abort_if((! $mustBeSubscribed) && $billingService->isSubscribed($user), code: 403, message: 'user already subscribed, access denied');
+
+        abort_if($mustBeSubscribed && (! $billingService->isSubscribed($user)), code: 403, message: 'subscription required');
+
+        return $next($request);
+    }
+}

--- a/backend/app/Http/Requests/CheckoutRequest.php
+++ b/backend/app/Http/Requests/CheckoutRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CheckoutRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'success_url' => ['required', 'url'],
+            'cancel_url' => ['required', 'url'],
+        ];
+    }
+}

--- a/backend/app/Http/Resources/UserResource.php
+++ b/backend/app/Http/Resources/UserResource.php
@@ -17,6 +17,9 @@ class UserResource extends JsonResource
         return [
             'name' => $this->name,
             'email' => $this->email,
+            'billing' => [
+                'isSubscribed' => billing()->isSubscribed($this->resource),
+            ],
         ];
     }
 }

--- a/backend/app/Models/Subscription.php
+++ b/backend/app/Models/Subscription.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Laravel\Cashier\Subscription as CashierSubscription;
+
+class Subscription extends CashierSubscription
+{
+    // NOTE: for the future in case we want to override of hook in
+}

--- a/backend/app/Models/SubscriptionItem.php
+++ b/backend/app/Models/SubscriptionItem.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Laravel\Cashier\SubscriptionItem as CashierSubscriptionItem;
+
+class SubscriptionItem extends CashierSubscriptionItem
+{
+    // NOTE: for the future in case we want to override of hook in
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -7,12 +7,13 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Cashier\Billable;
 use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasApiTokens, HasFactory,Notifiable;
+    use Billable, HasApiTokens,HasFactory, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -2,12 +2,15 @@
 
 namespace App\Providers;
 
+use App\Models\Subscription;
+use App\Models\SubscriptionItem;
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Cashier\Cashier;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -24,10 +27,22 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        $this->configureLaravelFramework();
+        $this->configureCachier();
+    }
+
+    private function configureCachier(): void
+    {
+
+        Cashier::useSubscriptionModel(Subscription::class);
+        Cashier::useSubscriptionItemModel(SubscriptionItem::class);
+    }
+
+    private function configureLaravelFramework(): void
+    {
         ResetPassword::createUrlUsing(function (object $notifiable, string $token) {
             return config('app.frontend_url')."/password-reset/$token?email={$notifiable->getEmailForPasswordReset()}";
         });
-
         Model::unguard();
         DB::prohibitDestructiveCommands($this->app->isProduction());
         Date::use(CarbonImmutable::class);

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use App\Models\Subscription;
 use App\Models\SubscriptionItem;
+use App\Services\BillingServices\BillingService;
+use App\Services\BillingServices\StripeBillingService;
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Database\Eloquent\Model;
@@ -19,7 +21,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->configureBindings();
     }
 
     /**
@@ -46,5 +48,10 @@ class AppServiceProvider extends ServiceProvider
         Model::unguard();
         DB::prohibitDestructiveCommands($this->app->isProduction());
         Date::use(CarbonImmutable::class);
+    }
+
+    private function configureBindings()
+    {
+        $this->app->bind(BillingService::class, StripeBillingService::class);
     }
 }

--- a/backend/app/Services/BillingServices/BillingService.php
+++ b/backend/app/Services/BillingServices/BillingService.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Services\BillingServices;
+
+use App\Models\User;
+
+interface BillingService
+{
+    public function buildCheckoutLink(User $user, string $successUrl, string $cancelUrl): string;
+
+    public function isSubscribed(User $user): bool;
+
+    // other methods like unsubscribe, refund ...
+}

--- a/backend/app/Services/BillingServices/FakeBillingService.php
+++ b/backend/app/Services/BillingServices/FakeBillingService.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Services\BillingServices;
+
+use App\Models\User;
+
+class FakeBillingService implements BillingService
+{
+    public function buildCheckoutLink(User $user, string $successUrl, string $cancelUrl): string
+    {
+        return $successUrl;
+    }
+
+    public function isSubscribed(User $user): bool
+    {
+        throw new \Exception('this should be mocked only');
+    }
+}

--- a/backend/app/Services/BillingServices/StripeBillingService.php
+++ b/backend/app/Services/BillingServices/StripeBillingService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Services\BillingServices;
+
+use App\Models\User;
+
+class StripeBillingService implements BillingService
+{
+    public function buildCheckoutLink(User $user, string $successUrl, string $cancelUrl): string
+    {
+        return $user
+            ->newSubscription('default', config('billing.price_id'))
+            ->checkout([
+                'success_url' => $successUrl,
+                'cancel_url' => $cancelUrl,
+            ])
+            ->url;
+    }
+
+    public function isSubscribed(User $user): bool
+    {
+        return $user->subscribed();
+    }
+}

--- a/backend/app/helpers.php
+++ b/backend/app/helpers.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\Services\BillingServices\BillingService;
+
+if (! function_exists('billing')) {
+
+    /**
+     * get the billing instance
+     */
+    function billing(): BillingService
+    {
+        return app(BillingService::class);
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -20,7 +20,7 @@ return Application::configure(basePath: dirname(__DIR__))
             ]);
 
         // NOTE: for demo only, because I don't have ability to set cookies under vercel domain
-        $middleware->validateCsrfTokens(except: ['*']);
+        $middleware->validateCsrfTokens(except: ['*','stripe/*']);
 
         //
     })

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\RequiresSubscriptionMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -12,18 +13,18 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        $middleware->api(prepend: [
-            // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
-        ])
+        $middleware
+
             ->alias([
                 'verified' => \App\Http\Middleware\EnsureEmailIsVerified::class,
-            ]);
+                'subscription' => RequiresSubscriptionMiddleware::class,
+            ])
 
-        // NOTE: for demo only, because I don't have ability to set cookies under vercel domain
-        $middleware->validateCsrfTokens(except: ['*','stripe/*']);
-
-        //
+            // NOTE: for demo only, because I don't have ability to set cookies under vercel domain
+            ->validateCsrfTokens(except: ['*', 'stripe/*']);
     })
+
     ->withExceptions(function (Exceptions $exceptions) {
         //
-    })->create();
+    })
+    ->create();

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -32,7 +32,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": [
+            "app/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -10,22 +10,22 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "laravel/cashier": "^15.6",
-        "laravel/framework": "^11.31",
-        "laravel/sanctum": "^4.0",
+        "laravel/cashier": "^15.6.2",
+        "laravel/framework": "^11.44",
+        "laravel/sanctum": "^4.0.8",
         "laravel/telescope": "^5.5",
-        "laravel/tinker": "^2.9"
+        "laravel/tinker": "^2.10.1"
     },
     "require-dev": {
-        "barryvdh/laravel-ide-helper": "^3.5",
-        "fakerphp/faker": "^1.23",
-        "laravel/breeze": "^2.3",
-        "laravel/pail": "^1.1",
-        "laravel/pint": "^1.13",
-        "laravel/sail": "^1.26",
-        "mockery/mockery": "^1.6",
-        "nunomaduro/collision": "^8.1",
-        "phpunit/phpunit": "^11.0.1"
+        "barryvdh/laravel-ide-helper": "^3.5.5",
+        "fakerphp/faker": "^1.24.1",
+        "laravel/breeze": "^2.3.5",
+        "laravel/pail": "^1.2.2",
+        "laravel/pint": "^1.21",
+        "laravel/sail": "^1.41",
+        "mockery/mockery": "^1.6.12",
+        "nunomaduro/collision": "^8.6.1",
+        "phpunit/phpunit": "^11.5.10"
     },
     "autoload": {
         "psr-4": {

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -10,6 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "laravel/cashier": "^15.6",
         "laravel/framework": "^11.31",
         "laravel/sanctum": "^4.0",
         "laravel/telescope": "^5.5",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -1144,16 +1144,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v11.43.2",
+            "version": "v11.44.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "99d1573698abc42222f04d25fcd5b213d0eedf21"
+                "reference": "e9a33da34815ac1ed46c7e4c477a775f4592f0a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/99d1573698abc42222f04d25fcd5b213d0eedf21",
-                "reference": "99d1573698abc42222f04d25fcd5b213d0eedf21",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/e9a33da34815ac1ed46c7e4c477a775f4592f0a7",
+                "reference": "e9a33da34815ac1ed46c7e4c477a775f4592f0a7",
                 "shasum": ""
             },
             "require": {
@@ -1355,7 +1355,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-02-19T21:53:48+00:00"
+            "time": "2025-02-24T13:08:54+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -6737,29 +6737,29 @@
         },
         {
             "name": "laravel/breeze",
-            "version": "v2.3.4",
+            "version": "v2.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/breeze.git",
-                "reference": "e456fe0db93d1f9f5ce3b2043739a0777404395c"
+                "reference": "1d85805c4aecc425a0ce157147384d4becea3fa2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/breeze/zipball/e456fe0db93d1f9f5ce3b2043739a0777404395c",
-                "reference": "e456fe0db93d1f9f5ce3b2043739a0777404395c",
+                "url": "https://api.github.com/repos/laravel/breeze/zipball/1d85805c4aecc425a0ce157147384d4becea3fa2",
+                "reference": "1d85805c4aecc425a0ce157147384d4becea3fa2",
                 "shasum": ""
             },
             "require": {
-                "illuminate/console": "^11.0",
-                "illuminate/filesystem": "^11.0",
-                "illuminate/support": "^11.0",
-                "illuminate/validation": "^11.0",
+                "illuminate/console": "^11.0|^12.0",
+                "illuminate/filesystem": "^11.0|^12.0",
+                "illuminate/support": "^11.0|^12.0",
+                "illuminate/validation": "^11.0|^12.0",
                 "php": "^8.2.0",
                 "symfony/console": "^7.0"
             },
             "require-dev": {
-                "laravel/framework": "^11.0",
-                "orchestra/testbench-core": "^9.0",
+                "laravel/framework": "^11.0|^12.0",
+                "orchestra/testbench-core": "^9.0|^10.0",
                 "phpstan/phpstan": "^2.0"
             },
             "type": "library",
@@ -6794,7 +6794,7 @@
                 "issues": "https://github.com/laravel/breeze/issues",
                 "source": "https://github.com/laravel/breeze"
             },
-            "time": "2025-02-11T13:19:28+00:00"
+            "time": "2025-02-19T23:49:42+00:00"
         },
         {
             "name": "laravel/pail",
@@ -7364,23 +7364,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "11.0.8",
+            "version": "11.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "418c59fd080954f8c4aa5631d9502ecda2387118"
+                "reference": "14d63fbcca18457e49c6f8bebaa91a87e8e188d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/418c59fd080954f8c4aa5631d9502ecda2387118",
-                "reference": "418c59fd080954f8c4aa5631d9502ecda2387118",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/14d63fbcca18457e49c6f8bebaa91a87e8e188d7",
+                "reference": "14d63fbcca18457e49c6f8bebaa91a87e8e188d7",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^5.3.1",
+                "nikic/php-parser": "^5.4.0",
                 "php": ">=8.2",
                 "phpunit/php-file-iterator": "^5.1.0",
                 "phpunit/php-text-template": "^4.0.1",
@@ -7392,7 +7392,7 @@
                 "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.5.0"
+                "phpunit/phpunit": "^11.5.2"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -7430,7 +7430,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.8"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.9"
             },
             "funding": [
                 {
@@ -7438,7 +7438,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-11T12:34:27+00:00"
+            "time": "2025-02-25T13:26:39+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -7687,16 +7687,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.9",
+            "version": "11.5.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c91c830e7108a81e5845aeb6ba8fe3c1a4351c0b"
+                "reference": "d5df2b32d729562ff8db634678d71085ee579006"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c91c830e7108a81e5845aeb6ba8fe3c1a4351c0b",
-                "reference": "c91c830e7108a81e5845aeb6ba8fe3c1a4351c0b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d5df2b32d729562ff8db634678d71085ee579006",
+                "reference": "d5df2b32d729562ff8db634678d71085ee579006",
                 "shasum": ""
             },
             "require": {
@@ -7768,7 +7768,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.9"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.10"
             },
             "funding": [
                 {
@@ -7784,7 +7784,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-21T06:08:50+00:00"
+            "time": "2025-02-25T06:11:48+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c61d53a80b9f9ec1a34df57b32a797a4",
+    "content-hash": "888e02d6150ba36e7cc9a2a906ddacb8",
     "packages": [
         {
             "name": "brick/math",
@@ -1053,6 +1053,94 @@
                 }
             ],
             "time": "2025-02-03T10:55:03+00:00"
+        },
+        {
+            "name": "laravel/cashier",
+            "version": "v15.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/cashier-stripe.git",
+                "reference": "a805191e63744a5cc73c864eba1194a721e2e8b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/cashier-stripe/zipball/a805191e63744a5cc73c864eba1194a721e2e8b0",
+                "reference": "a805191e63744a5cc73c864eba1194a721e2e8b0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^10.0|^11.0|^12.0",
+                "illuminate/contracts": "^10.0|^11.0|^12.0",
+                "illuminate/database": "^10.0|^11.0|^12.0",
+                "illuminate/http": "^10.0|^11.0|^12.0",
+                "illuminate/log": "^10.0|^11.0|^12.0",
+                "illuminate/notifications": "^10.0|^11.0|^12.0",
+                "illuminate/pagination": "^10.0|^11.0|^12.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0",
+                "illuminate/view": "^10.0|^11.0|^12.0",
+                "moneyphp/money": "^4.0",
+                "nesbot/carbon": "^2.0|^3.0",
+                "php": "^8.1",
+                "stripe/stripe-php": "^16.2",
+                "symfony/console": "^6.0|^7.0",
+                "symfony/http-kernel": "^6.0|^7.0",
+                "symfony/polyfill-intl-icu": "^1.22.1"
+            },
+            "require-dev": {
+                "dompdf/dompdf": "^2.0",
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^8.18|^9.0|^10.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^10.4|^11.5"
+            },
+            "suggest": {
+                "dompdf/dompdf": "Required when generating and downloading invoice PDF's using Dompdf (^1.0.1|^2.0).",
+                "ext-intl": "Allows for more locales besides the default \"en\" when formatting money values."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Cashier\\CashierServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "15.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Cashier\\": "src/",
+                    "Laravel\\Cashier\\Database\\Factories\\": "database/factories/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Dries Vints",
+                    "email": "dries@laravel.com"
+                }
+            ],
+            "description": "Laravel Cashier provides an expressive, fluent interface to Stripe's subscription billing services.",
+            "keywords": [
+                "billing",
+                "laravel",
+                "stripe"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/cashier/issues",
+                "source": "https://github.com/laravel/cashier"
+            },
+            "time": "2025-01-28T15:46:16+00:00"
         },
         {
             "name": "laravel/framework",
@@ -2138,6 +2226,94 @@
                 }
             ],
             "time": "2024-12-08T08:18:47+00:00"
+        },
+        {
+            "name": "moneyphp/money",
+            "version": "v4.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/moneyphp/money.git",
+                "reference": "ddf6a86b574808f8844777ed4e8c4f92a10dac9b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/moneyphp/money/zipball/ddf6a86b574808f8844777ed4e8c4f92a10dac9b",
+                "reference": "ddf6a86b574808f8844777ed4e8c4f92a10dac9b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-bcmath": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "cache/taggable-cache": "^1.1.0",
+                "doctrine/coding-standard": "^12.0",
+                "doctrine/instantiator": "^1.5.0 || ^2.0",
+                "ext-gmp": "*",
+                "ext-intl": "*",
+                "florianv/exchanger": "^2.8.1",
+                "florianv/swap": "^4.3.0",
+                "moneyphp/crypto-currencies": "^1.1.0",
+                "moneyphp/iso-currencies": "^3.4",
+                "php-http/message": "^1.16.0",
+                "php-http/mock-client": "^1.6.0",
+                "phpbench/phpbench": "^1.2.5",
+                "phpunit/phpunit": "^10.5.9",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "psr/cache": "^1.0.1 || ^2.0 || ^3.0",
+                "vimeo/psalm": "~5.20.0"
+            },
+            "suggest": {
+                "ext-gmp": "Calculate without integer limits",
+                "ext-intl": "Format Money objects with intl",
+                "florianv/exchanger": "Exchange rates library for PHP",
+                "florianv/swap": "Exchange rates library for PHP",
+                "psr/cache-implementation": "Used for Currency caching"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Money\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Verraes",
+                    "email": "mathias@verraes.net",
+                    "homepage": "http://verraes.net"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                },
+                {
+                    "name": "Frederik Bosch",
+                    "email": "f.bosch@genkgo.nl"
+                }
+            ],
+            "description": "PHP implementation of Fowler's Money pattern",
+            "homepage": "http://moneyphp.org",
+            "keywords": [
+                "Value Object",
+                "money",
+                "vo"
+            ],
+            "support": {
+                "issues": "https://github.com/moneyphp/money/issues",
+                "source": "https://github.com/moneyphp/money/tree/v4.6.0"
+            },
+            "time": "2024-11-22T10:59:03+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -3433,6 +3609,65 @@
             "time": "2024-04-27T21:32:50+00:00"
         },
         {
+            "name": "stripe/stripe-php",
+            "version": "v16.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stripe/stripe-php.git",
+                "reference": "d6de0a536f00b5c5c74f36b8f4d0d93b035499ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/d6de0a536f00b5c5c74f36b8f4d0d93b035499ff",
+                "reference": "d6de0a536f00b5c5c74f36b8f4d0d93b035499ff",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.5.0",
+                "phpstan/phpstan": "^1.2",
+                "phpunit/phpunit": "^5.7 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stripe\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stripe and contributors",
+                    "homepage": "https://github.com/stripe/stripe-php/contributors"
+                }
+            ],
+            "description": "Stripe PHP Library",
+            "homepage": "https://stripe.com/",
+            "keywords": [
+                "api",
+                "payment processing",
+                "stripe"
+            ],
+            "support": {
+                "issues": "https://github.com/stripe/stripe-php/issues",
+                "source": "https://github.com/stripe/stripe-php/tree/v16.6.0"
+            },
+            "time": "2025-02-24T22:35:29+00:00"
+        },
+        {
             "name": "symfony/clock",
             "version": "v7.2.0",
             "source": {
@@ -4522,6 +4757,90 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-icu",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-icu.git",
+                "reference": "d80a05e9904d2c2b9b95929f3e4b5d3a8f418d78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/d80a05e9904d2c2b9b95929f3e4b5d3a8f418d78",
+                "reference": "d80a05e9904d2c2b9b95929f3e4b5d3a8f418d78",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance and support of other locales than \"en\""
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Icu\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's ICU-related data and classes",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "icu",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.31.0"
             },
             "funding": [
                 {

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "888e02d6150ba36e7cc9a2a906ddacb8",
+    "content-hash": "8d1409e62c1719e0e6f9e1b6501e3449",
     "packages": [
         {
             "name": "brick/math",

--- a/backend/config/billing.php
+++ b/backend/config/billing.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'price_id' => env('STRIPE_SUBSCRIPTION_PRICE_ID', null),
+];

--- a/backend/config/cashier.php
+++ b/backend/config/cashier.php
@@ -1,0 +1,125 @@
+<?php
+
+use Laravel\Cashier\Console\WebhookCommand;
+use Laravel\Cashier\Invoices\DompdfInvoiceRenderer;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stripe Keys
+    |--------------------------------------------------------------------------
+    |
+    | The Stripe publishable key and secret key give you access to Stripe's
+    | API. The "publishable" key is typically used when interacting with
+    | Stripe.js while the "secret" key accesses private API endpoints.
+    |
+    */
+
+    'key' => env('STRIPE_KEY'),
+
+    'secret' => env('STRIPE_SECRET'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cashier Path
+    |--------------------------------------------------------------------------
+    |
+    | This is the base URI path where Cashier's views, such as the payment
+    | verification screen, will be available from. You're free to tweak
+    | this path according to your preferences and application design.
+    |
+    */
+
+    'path' => env('CASHIER_PATH', 'stripe'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stripe Webhooks
+    |--------------------------------------------------------------------------
+    |
+    | Your Stripe webhook secret is used to prevent unauthorized requests to
+    | your Stripe webhook handling controllers. The tolerance setting will
+    | check the drift between the current time and the signed request's.
+    |
+    */
+
+    'webhook' => [
+        'secret' => env('STRIPE_WEBHOOK_SECRET'),
+        'tolerance' => env('STRIPE_WEBHOOK_TOLERANCE', 300),
+        'events' => WebhookCommand::DEFAULT_EVENTS,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Currency
+    |--------------------------------------------------------------------------
+    |
+    | This is the default currency that will be used when generating charges
+    | from your application. Of course, you are welcome to use any of the
+    | various world currencies that are currently supported via Stripe.
+    |
+    */
+
+    'currency' => env('CASHIER_CURRENCY', 'usd'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Currency Locale
+    |--------------------------------------------------------------------------
+    |
+    | This is the default locale in which your money values are formatted in
+    | for display. To utilize other locales besides the default en locale
+    | verify you have the "intl" PHP extension installed on the system.
+    |
+    */
+
+    'currency_locale' => env('CASHIER_CURRENCY_LOCALE', 'en'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Payment Confirmation Notification
+    |--------------------------------------------------------------------------
+    |
+    | If this setting is enabled, Cashier will automatically notify customers
+    | whose payments require additional verification. You should listen to
+    | Stripe's webhooks in order for this feature to function correctly.
+    |
+    */
+
+    'payment_notification' => env('CASHIER_PAYMENT_NOTIFICATION'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Invoice Settings
+    |--------------------------------------------------------------------------
+    |
+    | The following options determine how Cashier invoices are converted from
+    | HTML into PDFs. You're free to change the options based on the needs
+    | of your application or your preferences regarding invoice styling.
+    |
+    */
+
+    'invoices' => [
+        'renderer' => env('CASHIER_INVOICE_RENDERER', DompdfInvoiceRenderer::class),
+
+        'options' => [
+            // Supported: 'letter', 'legal', 'A4'
+            'paper' => env('CASHIER_PAPER', 'letter'),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stripe Logger
+    |--------------------------------------------------------------------------
+    |
+    | This setting defines which logging channel will be used by the Stripe
+    | library to write log messages. You are free to specify any of your
+    | logging channels listed inside the "logging" configuration file.
+    |
+    */
+
+    'logger' => env('CASHIER_LOGGER'),
+
+];

--- a/backend/database/migrations/2025_02_25_130345_create_customer_columns.php
+++ b/backend/database/migrations/2025_02_25_130345_create_customer_columns.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('stripe_id')->nullable()->index();
+            $table->string('pm_type')->nullable();
+            $table->string('pm_last_four', 4)->nullable();
+            $table->timestamp('trial_ends_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropIndex([
+                'stripe_id',
+            ]);
+
+            $table->dropColumn([
+                'stripe_id',
+                'pm_type',
+                'pm_last_four',
+                'trial_ends_at',
+            ]);
+        });
+    }
+};

--- a/backend/database/migrations/2025_02_25_130345_create_subscription_items_table.php
+++ b/backend/database/migrations/2025_02_25_130345_create_subscription_items_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('subscription_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('subscription_id');
+            $table->string('stripe_id')->unique();
+            $table->string('stripe_product');
+            $table->string('stripe_price');
+            $table->integer('quantity')->nullable();
+            $table->timestamps();
+
+            $table->index(['subscription_id', 'stripe_price']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('subscription_items');
+    }
+};

--- a/backend/database/migrations/2025_02_25_130345_create_subscriptions_table.php
+++ b/backend/database/migrations/2025_02_25_130345_create_subscriptions_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('subscriptions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id');
+            $table->string('type');
+            $table->string('stripe_id')->unique();
+            $table->string('stripe_status');
+            $table->string('stripe_price')->nullable();
+            $table->integer('quantity')->nullable();
+            $table->timestamp('trial_ends_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'stripe_status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('subscriptions');
+    }
+};

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   stripe-cli: # for local testing of stripe webhooks
     image: stripe/stripe-cli
+    network_mode: host
     container_name: stripe-cli
     command: "listen --api-key ${STRIPE_SECRET} --device-name ${STRIPE_DEVICE_NAME} --forward-to ${APP_URL}/stripe/webhook/"
     env_file:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  stripe-cli: # for local testing of stripe webhooks
+    image: stripe/stripe-cli
+    container_name: stripe-cli
+    command: "listen --api-key ${STRIPE_SECRET} --device-name ${STRIPE_DEVICE_NAME} --forward-to ${APP_URL}/stripe/webhook/"
+    env_file:
+      - .env

--- a/backend/routes/api/api_v1.php
+++ b/backend/routes/api/api_v1.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Auth\EmailVerificationNotificationController;
 use App\Http\Controllers\Auth\VerifyEmailController;
 use App\Http\Controllers\CheckoutController;
+use App\Http\Controllers\PremiumQuoteController;
 use App\Http\Controllers\TaskController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
@@ -23,5 +24,7 @@ Route::prefix('v1')->group(function () {
 
         //NOTE: would in web.php with a redirect response
         Route::post('/subscription-checkout', CheckoutController::class);
+
+        Route::get('/quote',PremiumQuoteController::class)->middleware('subscription:1');
     });
 });

--- a/backend/routes/api/api_v1.php
+++ b/backend/routes/api/api_v1.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Auth\EmailVerificationNotificationController;
 use App\Http\Controllers\Auth\VerifyEmailController;
+use App\Http\Controllers\CheckoutController;
 use App\Http\Controllers\TaskController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
@@ -19,5 +20,8 @@ Route::prefix('v1')->group(function () {
         Route::post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
             ->middleware(['throttle:6,1'])
             ->name('verification.send');
+
+        //NOTE: would in web.php with a redirect response
+        Route::post('/subscription-checkout', CheckoutController::class);
     });
 });

--- a/backend/routes/api/api_v1.php
+++ b/backend/routes/api/api_v1.php
@@ -22,9 +22,9 @@ Route::prefix('v1')->group(function () {
             ->middleware(['throttle:6,1'])
             ->name('verification.send');
 
-        //NOTE: would in web.php with a redirect response
+        // NOTE: would in web.php with a redirect response
         Route::post('/subscription-checkout', CheckoutController::class);
 
-        Route::get('/quote',PremiumQuoteController::class)->middleware('subscription:1');
+        Route::get('/quote', PremiumQuoteController::class)->middleware('subscription:1');
     });
 });

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Http\Controllers\CheckoutController;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
 
@@ -10,6 +9,5 @@ Route::get('/', function () {
 
     return "<body style='background-color:black; color:white;'>$quote</body>";
 });
-
 
 require __DIR__.'/auth.php';

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\CheckoutController;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
 
@@ -9,5 +10,6 @@ Route::get('/', function () {
 
     return "<body style='background-color:black; color:white;'>$quote</body>";
 });
+
 
 require __DIR__.'/auth.php';

--- a/backend/tests/Feature/Api/V1/BillingTest.php
+++ b/backend/tests/Feature/Api/V1/BillingTest.php
@@ -25,7 +25,7 @@ class BillingTest extends TestCase
 
             ->assertCreated()
             ->assertJsonStructure(['data' => [
-                'checkout-link',
+                'checkoutLink',
             ]]);
     }
 

--- a/backend/tests/Feature/Api/V1/BillingTest.php
+++ b/backend/tests/Feature/Api/V1/BillingTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use App\Services\BillingServices\BillingService;
+use App\Services\BillingServices\FakeBillingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BillingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_checkout()
+    {
+
+        $user = User::factory()->create();
+        $url = config('app.url');
+        $this->app->bind(BillingService::class, FakeBillingService::class);
+
+        $this->actingAs($user);
+        $this
+            ->apiCall('post', 'subscription-checkout', ['success_url' => $url, 'cancel_url' => $url])
+
+            ->assertCreated()
+            ->assertJsonStructure(['data' => [
+                'checkout-link',
+            ]]);
+    }
+
+    public function test_checkout_is_validated()
+    {
+        $user = User::factory()->create();
+
+        $this->app->bind(BillingService::class, FakeBillingService::class);
+
+        $this->actingAs($user);
+        $this
+            ->apiCall('post', 'subscription-checkout')
+            ->assertJsonValidationErrors(['success_url', 'cancel_url']);
+
+        $this
+            ->apiCall('post', 'subscription-checkout', ['success_url' => 'not a link', 'cancel_url' => 'not a link'])
+            ->assertJsonValidationErrors(['success_url', 'cancel_url']);
+    }
+}

--- a/backend/tests/Feature/Api/V1/BillingTest.php
+++ b/backend/tests/Feature/Api/V1/BillingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Feature\Api\V1;
 
 use App\Models\User;
 use App\Services\BillingServices\BillingService;

--- a/backend/tests/Feature/Api/V1/QuoteTest.php
+++ b/backend/tests/Feature/Api/V1/QuoteTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\User;
+use App\Services\BillingServices\BillingService;
+use App\Services\BillingServices\FakeBillingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+class QuoteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_freemium_user_cant_get_quote()
+    {
+        $user = User::factory()->create();
+
+        $this->instance(BillingService::class, Mockery::mock(FakeBillingService::class, function (MockInterface $mock) {
+            $mock
+                ->shouldReceive('isSubscribed')
+                ->andReturn(false);
+        }));
+
+        $this
+            ->actingAs($user)
+            ->apiCall('get', 'quote')
+            ->assertForbidden();
+    }
+
+    public function test_premium_user_cant_get_quote()
+    {
+        $user = User::factory()->create();
+
+        $this->instance(BillingService::class, Mockery::mock(FakeBillingService::class, function (MockInterface $mock) {
+            $mock
+                ->shouldReceive('isSubscribed')
+                ->andReturn(true);
+        }));
+
+        $this
+            ->actingAs($user)
+            ->apiCall('get', 'quote')
+            ->assertCreated()
+            ->assertJsonStructure([
+                'data' => ['quote'],
+            ]);
+    }
+}

--- a/backend/tests/Feature/Api/V1/QuoteTest.php
+++ b/backend/tests/Feature/Api/V1/QuoteTest.php
@@ -43,7 +43,7 @@ class QuoteTest extends TestCase
         $this
             ->actingAs($user)
             ->apiCall('get', 'quote')
-            ->assertCreated()
+            ->assertOk()
             ->assertJsonStructure([
                 'data' => ['quote'],
             ]);

--- a/backend/tests/Feature/Api/V1/TaskApiTest.php
+++ b/backend/tests/Feature/Api/V1/TaskApiTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Api\V1\Api;
+namespace Tests\Feature\Api\V1;
 
 use App\Enums\TaskStatus;
 use App\Models\Task;

--- a/backend/tests/Unit/MiddlewareTest.php
+++ b/backend/tests/Unit/MiddlewareTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Middleware\RequiresSubscriptionMiddleware;
+use App\Models\User;
+use App\Services\BillingServices\BillingService;
+use App\Services\BillingServices\FakeBillingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Mockery;
+use Mockery\MockInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+class MiddlewareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Setup a request , a next closure and a middleware instance
+     */
+    private function arrange(string $middlewareClass): array
+    {
+
+        $next = function (): Response {
+            return response('success');
+        };
+
+        $middleware = new $middlewareClass;
+
+        $user = User::factory()->create();
+
+        return [$user, $next, $middleware];
+    }
+
+    public function test_requires_subscription_middleware(): void
+    {
+        [$user , $next, $middleware] = $this->arrange(RequiresSubscriptionMiddleware::class);
+
+        $cases = [
+            [
+                'requiresSub' => true,
+                'isSubscribed' => true,
+                'expect' => 200,
+            ],
+
+            [
+                'requiresSub' => false,
+                'isSubscribed' => false,
+                'expect' => 200,
+            ],
+
+            [
+                'requiresSub' => false,
+                'isSubscribed' => true,
+                'expect' => 403, //todo
+            ],
+
+            [
+                'requiresSub' => true,
+                'isSubscribed' => false,
+                'expect' => 403,
+            ],
+
+        ];
+
+        $this->actingAs($user);
+
+        $this->app->bind(BillingService::class, FakeBillingService::class);
+
+        foreach ($cases as $case) {
+            $this->instance(FakeBillingService::class, Mockery::mock(FakeBillingService::class, function (MockInterface $mock) use ($case) {
+                $mock->shouldReceive('isSubscribed')
+                    ->andReturn($case['isSubscribed']);
+            }));
+
+            $request = Request::create(route('login'));
+
+            $request->setUserResolver(fn () => $user);
+
+            try {
+                $response = $middleware->handle($request, $next, $case['requiresSub']);
+                $this->assertEquals($case['expect'], $response->getStatusCode());
+            } catch (\Throwable $e) {
+                $this->assertEquals($case['expect'], $e->getStatusCode());
+            }
+        }
+
+    }
+}

--- a/backend/tests/Unit/MiddlewareTest.php
+++ b/backend/tests/Unit/MiddlewareTest.php
@@ -55,7 +55,7 @@ class MiddlewareTest extends TestCase
             [
                 'requiresSub' => false,
                 'isSubscribed' => true,
-                'expect' => 403, //todo
+                'expect' => 403, // todo
             ],
 
             [

--- a/bruno/shafaq/billing/checkout.bru
+++ b/bruno/shafaq/billing/checkout.bru
@@ -1,0 +1,29 @@
+meta {
+  name: checkout
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{v1}}/subscription-checkout
+  body: json
+  auth: bearer
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+  X-XSRF-TOKEN: {{X-XSRF-TOKEN}}
+  : 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}
+
+body:json {
+  {
+    "success_url": "http://localhost:3000?status=success",
+    "cancel_url": "http://localhost:3000?status=cancel"
+  }
+}

--- a/bruno/shafaq/billing/get a quote (premium).bru
+++ b/bruno/shafaq/billing/get a quote (premium).bru
@@ -1,0 +1,22 @@
+meta {
+  name: get a quote (premium)
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{v1}}/quote
+  body: json
+  auth: bearer
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+  X-XSRF-TOKEN: {{X-XSRF-TOKEN}}
+  : 
+}
+
+auth:bearer {
+  token: {{AUTH_TOKEN}}
+}

--- a/frontend/src/api/billing.ts
+++ b/frontend/src/api/billing.ts
@@ -1,0 +1,20 @@
+import apiCall from "@/lib/axios"
+import { NormalResponse } from "@/types/api"
+
+const prefix = 'api/v1'
+
+export async function checkout() {
+	return await apiCall<NormalResponse<{ checkoutLink: string }>>(
+		{
+			method: "post",
+			url: `${prefix}/subscription-checkout`,
+			data: {
+				success_url: import.meta.env.VITE_FRONTEND_URL + '/billing?status=success',
+				cancel_url: import.meta.env.VITE_FRONTEND_URL+ '/billing?status=canceled',
+			},
+			onSuccess: (data) => {
+				window.location.replace(data.data.checkoutLink)
+			},
+		}
+	)
+}

--- a/frontend/src/api/quote.ts
+++ b/frontend/src/api/quote.ts
@@ -1,0 +1,13 @@
+import apiCall from "@/lib/axios"
+import { NormalResponse } from "@/types/api"
+
+const prefix = 'api/v1/quote'
+
+export async function getQuote() {
+	return await apiCall<NormalResponse<{ quote: string }>>(
+		{
+			method: "get",
+			url: `${prefix}`
+		}
+	)
+}

--- a/frontend/src/components/common/Popup.tsx
+++ b/frontend/src/components/common/Popup.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, ReactNode, useEffect } from 'react';
+import { PropsWithChildren, useEffect } from 'react';
 
 export interface PopupProps extends PropsWithChildren {
   open: boolean;

--- a/frontend/src/components/common/Popup.tsx
+++ b/frontend/src/components/common/Popup.tsx
@@ -1,8 +1,7 @@
-import { ReactNode, useEffect } from 'react';
+import { PropsWithChildren, ReactNode, useEffect } from 'react';
 
-type PopupProps = {
+export interface PopupProps extends PropsWithChildren {
   open: boolean;
-  children: ReactNode;
   onClose?: () => void;
 };
 
@@ -26,7 +25,7 @@ export default function Popup({ open, children, onClose }: PopupProps) {
       onClick={onClose}
     >
       <div
-        className="bg-white rounded-lg shadow-xl p-6 max-w-sm w-full"
+        className="bg-white rounded-lg shadow-xl p-6 max-w-md w-full"
         onClick={(e) => e.stopPropagation()}
       >
         {children}

--- a/frontend/src/components/common/PremiumPopup.tsx
+++ b/frontend/src/components/common/PremiumPopup.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import LoadingBtn from "./LoadingBtn";
+import Popup, { PopupProps } from "./Popup";
+import { checkout } from "@/api/billing";
+
+export default function PremiumPopup(props: PopupProps) {
+  const [loading, setLoading] = useState(false);
+
+  async function subscriptionHandler() {
+    setLoading(true)
+    await checkout()
+    setLoading(false)
+  }
+
+  return (
+    <Popup {...props}>
+      <div>
+        <h1 className="text-3xl my-5 text-indigo-500 font-bold" >
+          Premium subscription
+        </h1>
+        <p className="font-semibold">
+          Subscribe to shafaq's premium plan and enjoy quality life saving features.
+        </p>
+
+        <p className="my-5 bg-gray-100 rounded-xl p-2 font-semibold">
+          Get wisdom quotes, increase motivation to finish your damn tasks
+        </p>
+
+        <LoadingBtn data-tooltip='Use fake credit card: 4242 4242 4242 4242' loading={loading} onClick={subscriptionHandler} className="w-full bg-indigo-600 text-white rounded-md py-2 px-4 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-opacity-50 text-white mt-4">
+          Subscribe
+        </LoadingBtn>
+      </div>
+    </Popup>
+  )
+}

--- a/frontend/src/css/globals.css
+++ b/frontend/src/css/globals.css
@@ -53,3 +53,35 @@ select:-webkit-autofill:focus {
 button {
   cursor: pointer;
 }
+
+
+/* lazy tooltip */
+
+[data-tooltip] {
+  position: relative;
+  border-bottom: 1px dashed #000;
+}
+
+[data-tooltip]::after {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  content: attr(data-tooltip);
+  left: 0;
+  top: calc(100% + 10px);
+  border-radius: 3px;
+  box-shadow: 0 0 5px 2px rgba(100, 100, 100, 0.6);
+  background-color: white;
+  z-index: 10;
+  padding: 8px;
+  width: 100%;
+  transform: translateY(-20px);
+  transition: all 150ms cubic-bezier(.25, .8, .25, 1);
+  color:black;
+}
+
+[data-tooltip]:hover::after {
+  opacity: 1;
+  transform: translateY(0);
+  transition-duration: 300ms;
+}

--- a/frontend/src/layouts/authenticated/index.tsx
+++ b/frontend/src/layouts/authenticated/index.tsx
@@ -5,11 +5,14 @@ import Header from './partials/Header.tsx';
 import { useEffect, useState } from 'react';
 import { getUser } from '@/api/user.ts';
 import PageLoader from '@/components/common/PageLoader.tsx';
+import PremiumPopup from '@/components/common/PremiumPopup.tsx';
+import { useUiStore } from '@/store/ui.ts';
 
 const AuthLayout = () => {
 
   const authStore = useAuthStore()
   const userStore = useUserStore()
+  const uiStore = useUiStore()
 
   const [loading, setLoading] = useState(true)
 
@@ -34,6 +37,7 @@ const AuthLayout = () => {
           }
           <Outlet />
         </div >
+        <PremiumPopup open={uiStore.premiumPopup} onClose={() => uiStore.togglePremiumPopup(false)} />
       </div >
     )
 };

--- a/frontend/src/layouts/authenticated/partials/Header.tsx
+++ b/frontend/src/layouts/authenticated/partials/Header.tsx
@@ -1,12 +1,56 @@
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import Logo from '@/components/common/Logo'
 import ProfileDropdown from "./ProfileDropDown";
+import { useUserStore } from "@/store/user";
+import { premiumChecker } from "@/lib/utils";
+import Popup from "@/components/common/Popup";
+import { User } from "@/types/models";
+import LoadingBtn from "@/components/common/LoadingBtn";
+import { getQuote } from "@/api/quote";
+import { useUiStore } from "@/store/ui";
 
 interface Props extends React.HTMLProps<HTMLDivElement> { }
 
 export default function Header(props: Props): ReactNode {
+	const userStore = useUserStore()
+	const uiStore = useUiStore()
+	const [isOpen, setIsOpen] = useState(false)
+	const [quote, setQuote] = useState('')
+	const [loading, setLoading] = useState(false)
+
+	async function handleGetQuote() {
+		setLoading(true)
+		const { data, error } = await getQuote()
+		setLoading(false)
+		if (error) return
+
+		setQuote(data.data.quote)
+		setIsOpen(true)
+	}
+
+	function closeQuotePopup() {
+		setIsOpen(false)
+		setQuote('')
+	}
+
 	return <header {...props} >
 		<Logo className='h-[50px]' />
-		<ProfileDropdown />
+		<div className="flex items-center gap-2">
+			<LoadingBtn
+				loading={loading}
+				data-premium
+				onClick={() => premiumChecker(userStore, uiStore, handleGetQuote)}
+				className="py-1 px-2 border text-indigo-500 rounded-lg w-20"
+			>
+				Wisdom
+			</LoadingBtn>
+			<ProfileDropdown />
+		</div>
+		<Popup open={isOpen}>
+			<p className="text-black">{quote}</p>
+			<button onClick={closeQuotePopup} className="w-full bg-indigo-600 text-white rounded-md py-2 px-4 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-opacity-50 text-white mt-4">
+				I agree
+			</button>
+		</Popup>
 	</header >
 }

--- a/frontend/src/layouts/authenticated/partials/Header.tsx
+++ b/frontend/src/layouts/authenticated/partials/Header.tsx
@@ -4,7 +4,6 @@ import ProfileDropdown from "./ProfileDropDown";
 import { useUserStore } from "@/store/user";
 import { premiumChecker } from "@/lib/utils";
 import Popup from "@/components/common/Popup";
-import { User } from "@/types/models";
 import LoadingBtn from "@/components/common/LoadingBtn";
 import { getQuote } from "@/api/quote";
 import { useUiStore } from "@/store/ui";

--- a/frontend/src/layouts/authenticated/partials/ProfileDropDown.tsx
+++ b/frontend/src/layouts/authenticated/partials/ProfileDropDown.tsx
@@ -37,6 +37,7 @@ export default function ProfileDropdown() {
 		return (<div className="flex gap-2 items-center">
 			<img src={Avatar} className="rounded-full w-[20px]" />
 			<span>{userStore.user?.name}</span>
+			<span className="text-xs text-indigo-500 capitalize">{userStore.user?.billing.isSubscribed ? 'premium' : 'freemium'}</span>
 		</div>)
 	}
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import { UiStore, useUiStore } from "@/store/ui";
+import { UserStore } from "@/store/user";
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
@@ -21,3 +23,12 @@ export function formatDate(date: Date): string {
 
 	return `${year}-${month}-${day}`;
 };
+
+export function premiumChecker(userStore: UserStore, uiStore: UiStore, handler: () => void) {
+	if (!userStore.user?.billing.isSubscribed) {
+		uiStore.togglePremiumPopup(true)
+		return
+	}
+
+	handler()
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { UiStore, useUiStore } from "@/store/ui";
+import { UiStore } from "@/store/ui";
 import { UserStore } from "@/store/user";
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,6 +10,7 @@ import boot from "@/lib/boot"
 import CreateTaskPage from './pages/dashboard/CreateTaskPage'
 import TaskPage from './pages/dashboard/TaskPage'
 import NotFound from './pages/404/NotFound'
+import BillingRedirectPage from './pages/billing'
 
 boot()
 
@@ -35,6 +36,8 @@ createRoot(document.getElementById('root')!).render(
           <Route path='create' element={<CreateTaskPage />} />
           <Route path=':taskId/:verb?' element={<TaskPage />} />
         </Route>
+
+        <Route path='billing' element={<BillingRedirectPage />} />
       </Route>
 
       <Route path='*' element={<NotFound />} />

--- a/frontend/src/pages/billing/index.tsx
+++ b/frontend/src/pages/billing/index.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+
+export default function BillingRedirectPage() {
+
+	const [searchParams] = useSearchParams()
+	const [counter, setCounter] = useState(3)
+
+	const navigate = useNavigate()
+
+
+	const interval = setInterval(() => {
+		setCounter(counter - 1)
+	}, 1000)
+
+	useEffect(() => {
+		setTimeout(() => {
+			clearInterval(interval)
+			navigate('/dashboard', { replace: true })
+		}, 3000);
+	}, [])
+
+	return (
+		<main className="w-full h-full text-xl sm:text-3xl font-bold grid place-items-center" >
+			<p>
+				{searchParams.get('status') === 'success' ? 'Your subscription is now active' : 'Payment canceled'}
+			</p>
+			<p>{counter}</p>
+		</main >
+	)
+}

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -68,7 +68,8 @@ const DashboardPage = () => {
 		}
 	];
 
-	async function asyncFetch() {
+	async function effect() {
+		setLoading(true)
 		let pageNum = searchParams.get('page')
 		if (!pageNum) {
 			setPage(1)
@@ -77,10 +78,11 @@ const DashboardPage = () => {
 		}
 
 		const { data, error, links, meta } = await getTasks(pageNum)
+		setLoading(false)
+
 		if (error) return
 		setTasks(data.data)
 		setPagination({ links, meta })
-
 	}
 
 	async function handleTaskDeletion() {
@@ -88,7 +90,7 @@ const DashboardPage = () => {
 
 		setLoading(true)
 		const { error } = await deleteTask(deletePopup.id)
-		await asyncFetch()
+		await effect()
 		setLoading(false)
 		if (error) return
 		clearDeletePopup()
@@ -99,7 +101,7 @@ const DashboardPage = () => {
 	}
 
 	useEffect(() => {
-		asyncFetch()
+		effect()
 	}, [searchParams])
 
 	if (loading) return <PageLoader />

--- a/frontend/src/store/ui.ts
+++ b/frontend/src/store/ui.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand'
+
+export type State = { premiumPopup: boolean }
+export type Action = {
+  togglePremiumPopup: (val?: boolean) => void,
+}
+
+export type UiStore = State & Action
+
+export const useUiStore = create<UiStore>((set, get) => ({
+  premiumPopup: false,
+  togglePremiumPopup: (val?: boolean) => {
+    if (val === undefined) val = get().premiumPopup
+
+    return set({ premiumPopup: val })
+  },
+}))

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -2,6 +2,7 @@ export type User = {
 	id: number;
 	name: string;
 	email: string;
+	billing: { isSubscribed: boolean }
 }
 
 //Task


### PR DESCRIPTION
# Summary
Used Laravel cashier with stripe to setup basic billing, users can subscribe to our default yearly plan and we can make a lot of money.

# Dev setup
- Must have stripe account with test mode
- Add env vars (see readme)
- Use Docker to run `stripe cli` and handle webhooks in your local setup (see readme)

# Steps to add a paid feature
- make a route
- `subscription:1` and `subscription:0` middleware protects routes based on if the user is subscribed or not (403) is returned.
- Frontend: `premiumCheck()` found in `lib/utils.ts` function handles every premium feature call
- Mark your cta with data-premium for tracking in case we need it one day